### PR TITLE
Add cursor-based pagination to avoid catalog fetch timeouts

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,8 @@
 
 require "bundler/setup"
 require "sports_south"
+require 'active_support'
+require 'active_support/core_ext/object/blank'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/sports_south.rb
+++ b/lib/sports_south.rb
@@ -1,10 +1,12 @@
 require 'sports_south/version'
 
 require 'cgi'
+require 'set'
 require 'json'
 require 'net/http'
 require 'nokogiri'
 require 'tempfile'
+require 'date'
 
 require 'sports_south/base'
 require 'sports_south/brand'

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -166,7 +166,7 @@ module SportsSouth
         caliber:           caliber,
         action:            action,
         map_price:         content_for(node, 'MFPRC'),
-        brand:             @brands[content_for(node, 'ITBRDNO').presence],
+        brand:             @brands[content_for(node, 'ITBRDNO').presence]&.dig(:name),
         features:          features,
         unit_of_measure:   unit_of_measure,
       }

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -33,7 +33,7 @@ module SportsSouth
 
       @options    = options
       @categories = SportsSouth::Category.all(options).to_h { |cat| [cat[:category_id], cat] }
-      @brands     = SportsSouth::Brand.all(options)
+      @brands     = SportsSouth::Brand.all(options).to_h { |brand| [brand[:brand_id], brand] }
     end
 
     def self.all(options = {})
@@ -47,7 +47,11 @@ module SportsSouth
 
       options[:last_item] ||= '-1'
 
-      new(options).all
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = new(options).all
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+      puts "total Catalog.all elapsed: #{format('%.3f', elapsed)}s"
+      result
     end
 
     def fetch_items(last_update: nil, last_item: nil)
@@ -163,7 +167,7 @@ module SportsSouth
         caliber:           caliber,
         action:            action,
         map_price:         content_for(node, 'MFPRC'),
-        brand:             content_for(node, 'ITBRDNO').presence,
+        brand:             @brands[content_for(node, 'ITBRDNO').presence],
         features:          features,
         unit_of_measure:   unit_of_measure,
       }
@@ -197,22 +201,9 @@ module SportsSouth
       features.transform_keys! { |k| k.gsub(/\s+/, '_').downcase.to_sym }
     end
 
-    def assign_brand_names(items)
-      brand_ids = items.collect { |item| item[:brand] }.uniq.compact
-
-      brand_ids.each do |brand_id|
-        brand_name = @brands.find { |brand| brand[:brand_id] == brand_id }.try(:[], :name)
-
-        next if brand_name.nil?
-
-        items.map! do |item|
-          item[:brand] = brand_name if item[:brand] == brand_id
-          item
-        end
-      end
-
-      items
+    # This request takes a while
+    def assign_item_long_description(item)
+      item[:long_description] = get_description(item[:item_identifier])
     end
-
   end
 end

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -32,17 +32,17 @@ module SportsSouth
       requires!(options, :username, :password)
 
       @options    = options
-      @categories = SportsSouth::Category.all(options)
+      @categories = SportsSouth::Category.all(options).to_h { |cat| [cat[:category_id], cat] }
       @brands     = SportsSouth::Brand.all(options)
     end
 
     def self.all(options = {})
       requires!(options, :username, :password)
 
-      if options[:last_updated]
-        options[:last_updated] = options[:last_updated].strftime("%-m/%-d/%Y")
+      if options[:last_update]
+        options[:last_update] = options[:last_update].strftime("%-m/%-d/%Y")
       else
-        options[:last_updated] ||= '1/1/1990'
+        options[:last_update] ||= '1/1/1990'
       end
 
       options[:last_item] ||= '-1'
@@ -50,16 +50,21 @@ module SportsSouth
       new(options).all
     end
 
-    def all
+    def fetch_items(last_update: nil, last_item: nil)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      global_start_time = start_time
+      items = []
+
       http, request = get_http_and_request(API_URL, '/DailyItemUpdate')
 
       request.set_form_data(form_params(@options).merge({
-        LastUpdate: @options[:last_updated],
-        LastItem:   @options[:last_item].to_s
+        LastUpdate: last_update,
+        LastItem:   last_item
       }))
 
-      items    = []
       tempfile = download_to_tempfile(http, request)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+      puts "fetch_items Download elapsed: #{format('%.3f', elapsed)}s"
 
       tempfile.rewind
 
@@ -69,15 +74,36 @@ module SportsSouth
 
         node = Nokogiri::XML.parse(reader.outer_xml)
 
-        _map_hash = map_hash(node.css(ITEM_NODE_NAME), @options[:full_product])
+        _map_hash = raw_map_hash(node.css(ITEM_NODE_NAME), @options[:full_product])
 
         items << _map_hash unless _map_hash.nil?
       end
 
-      tempfile.close
-      tempfile.unlink
 
-      assign_brand_names(items)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - global_start_time
+      puts "global fetch_items took: #{format('%.3f', elapsed)}s"
+      items
+    end
+
+    def all
+      puts "1st page fetch"
+      items = fetch_items(last_update: @options[:last_update], last_item: @options[:last_item])
+
+      pages = (daily_item_count.to_f/1000.0).ceil - 1
+      puts "page count: #{pages}"
+
+      if pages > 0
+        pages.times do |page| 
+
+          puts "now fetching page: #{page + 1}"
+          cursor = items.last[:item_identifier]
+
+          items.concat(fetch_items(last_update: @options[:last_update], last_item: cursor))
+        end
+      end
+      # assign_brand_names(items)
+
+      items
     end
 
     def self.get_description(item_number, options = {})
@@ -101,9 +127,13 @@ module SportsSouth
 
     protected
 
-    def map_hash(node, full_product = false)
-      category        = @categories.find { |category| category[:category_id] == content_for(node, 'CATID') }
-      features        = self.map_features(category.except(:category_id, :department_id, :department_description, :description), node)
+    def daily_item_count
+      SportsSouth::Inventory.daily_item_count(@options.slice(:username, :password, :last_update))
+    end
+
+    def raw_map_hash(node, full_product = false)
+      category        = @categories[content_for(node, 'CATID')]
+      features        = self.map_features(category, node)
       model           = content_for(node, 'IMODEL')
       series          = content_for(node, 'SERIES')
       mfg_number      = content_for(node, 'MFGINO')
@@ -124,7 +154,8 @@ module SportsSouth
         quantity:          content_for(node, 'QTYOH').to_i,
         price:             content_for(node, 'CPRC'),
         short_description: content_for(node, 'SHDESC'),
-        long_description:  (full_product ? get_description(content_for(node, 'ITEMNO')) : nil),
+        # long_description:  (full_product ? get_description(content_for(node, 'ITEMNO')) : nil),
+        long_description:  nil,
         category:          category[:description],
         product_type:      ITEM_TYPES[content_for(node, 'ITYPE')],
         mfg_number:        mfg_number,
@@ -162,9 +193,8 @@ module SportsSouth
         attributes[:attribute_20] => content_for(node, 'ITATR20')
       }
 
-      features.delete_if { |k, v| v.to_s.blank? }
-      features.transform_keys! { |k| k.gsub(/\s+/, '_').downcase }
-      features.symbolize_keys!
+      features.delete_if { |k, v| v.to_s.empty? }
+      features.transform_keys! { |k| k.gsub(/\s+/, '_').downcase.to_sym }
     end
 
     def assign_brand_names(items)

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -78,7 +78,8 @@ module SportsSouth
 
         node = Nokogiri::XML.parse(reader.outer_xml)
 
-        _map_hash = raw_map_hash(node.css(ITEM_NODE_NAME), @options[:full_product])
+        _map_hash = raw_map_hash(node.css(ITEM_NODE_NAME))
+        assign_item_long_description(_map_hash) if @options[:full_product] == true
 
         items << _map_hash unless _map_hash.nil?
       end
@@ -105,7 +106,6 @@ module SportsSouth
           items.concat(fetch_items(last_update: @options[:last_update], last_item: cursor))
         end
       end
-      # assign_brand_names(items)
 
       items
     end
@@ -135,7 +135,7 @@ module SportsSouth
       SportsSouth::Inventory.daily_item_count(@options.slice(:username, :password, :last_update))
     end
 
-    def raw_map_hash(node, full_product = false)
+    def raw_map_hash(node)
       category        = @categories[content_for(node, 'CATID')]
       features        = self.map_features(category, node)
       model           = content_for(node, 'IMODEL')
@@ -158,7 +158,6 @@ module SportsSouth
         quantity:          content_for(node, 'QTYOH').to_i,
         price:             content_for(node, 'CPRC'),
         short_description: content_for(node, 'SHDESC'),
-        # long_description:  (full_product ? get_description(content_for(node, 'ITEMNO')) : nil),
         long_description:  nil,
         category:          category[:description],
         product_type:      ITEM_TYPES[content_for(node, 'ITYPE')],

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -45,6 +45,16 @@ module SportsSouth
         options[:last_update] ||= '1/1/1990'
       end
 
+      # Pass a set in order to not include items with given upcs
+      # in the results. Also avoids requesting GetText for them
+      options[:upcs_to_not_process] ||= nil
+
+      # Pass full_product: true to get the full item description
+      # costs a secondary HTTP request per item
+      options[:full_product] ||= false
+
+      # Pass last_item: -1 to fetch the whole catalog. Pass a ITEMNO
+      # to fetch that item + 999 others (page cursor)
       options[:last_item] ||= '-1'
 
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -78,6 +88,8 @@ module SportsSouth
 
         node = Nokogiri::XML.parse(reader.outer_xml)
 
+        next if reject_upc?(node)
+
         _map_hash = raw_map_hash(node.css(ITEM_NODE_NAME))
         assign_item_long_description(_map_hash) if @options[:full_product] == true
 
@@ -98,7 +110,7 @@ module SportsSouth
       puts "page count: #{pages}"
 
       if pages > 0
-        pages.times do |page| 
+        pages.times do |page|
 
           puts "now fetching page: #{page + 1}"
           cursor = items.last[:item_identifier]
@@ -198,6 +210,16 @@ module SportsSouth
 
       features.delete_if { |k, v| v.to_s.empty? }
       features.transform_keys! { |k| k.gsub(/\s+/, '_').downcase.to_sym }
+    end
+
+    def reject_upc?(node)
+      return false if @options[:upcs_to_not_process].nil? || @options[:upcs_to_not_process].empty?
+
+      @options[:upcs_to_not_process].include?(upc_for_node(node).to_s)
+    end
+
+    def upc_for_node(node)
+      content_for(node, 'ITUPC').rjust(12, "0")
     end
 
     # This request takes a while

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -57,16 +57,10 @@ module SportsSouth
       # to fetch that item + 999 others (page cursor)
       options[:last_item] ||= '-1'
 
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result = new(options).all
-      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-      puts "total Catalog.all elapsed: #{format('%.3f', elapsed)}s"
-      result
+      new(options).all
     end
 
     def fetch_items(last_update: nil, last_item: nil)
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      global_start_time = start_time
       items = []
 
       http, request = get_http_and_request(API_URL, '/DailyItemUpdate')
@@ -77,9 +71,6 @@ module SportsSouth
       }))
 
       tempfile = download_to_tempfile(http, request)
-      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-      puts "fetch_items Download elapsed: #{format('%.3f', elapsed)}s"
-
       tempfile.rewind
 
       Nokogiri::XML::Reader.from_io(tempfile).each do |reader|
@@ -96,30 +87,33 @@ module SportsSouth
         items << _map_hash unless _map_hash.nil?
       end
 
-
-      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - global_start_time
-      puts "global fetch_items took: #{format('%.3f', elapsed)}s"
+      tempfile.close
+      tempfile.unlink
       items
     end
 
     def all
-      puts "1st page fetch"
-      items = fetch_items(last_update: @options[:last_update], last_item: @options[:last_item])
+      last_item = @options[:last_item]
+      last_update = @options[:last_update]
 
-      pages = (daily_item_count.to_f/1000.0).ceil - 1
-      puts "page count: #{pages}"
+      return fetch_items(last_update: last_update, last_item: last_item) if !use_pagination?
+      pages = (daily_item_count.to_f/1000.0).ceil
+      cursor = last_item
+      items = []
 
-      if pages > 0
-        pages.times do |page|
-
-          puts "now fetching page: #{page + 1}"
-          cursor = items.last[:item_identifier]
-
-          items.concat(fetch_items(last_update: @options[:last_update], last_item: cursor))
-        end
+      pages.times do |page|
+        items.concat(
+          fetch_items(last_update: last_update,
+                      last_item: cursor)
+        )
+        cursor = items.last[:item_identifier]
       end
 
       items
+    end
+
+    def use_pagination?
+      @options[:last_item].to_i > -1
     end
 
     def self.get_description(item_number, options = {})
@@ -148,7 +142,7 @@ module SportsSouth
     end
 
     def raw_map_hash(node)
-      category        = @categories[content_for(node, 'CATID')]
+      category        = @categories[content_for(node, 'CATID')] || {}
       features        = self.map_features(category, node)
       model           = content_for(node, 'IMODEL')
       series          = content_for(node, 'SERIES')
@@ -185,6 +179,8 @@ module SportsSouth
     end
 
     def map_features(attributes, node)
+      return {} if attributes.blank?
+
       features = {
         attributes[:attribute_1]  => content_for(node, 'ITATR1'),
         attributes[:attribute_2]  => content_for(node, 'ITATR2'),
@@ -208,7 +204,7 @@ module SportsSouth
         attributes[:attribute_20] => content_for(node, 'ITATR20')
       }
 
-      features.delete_if { |k, v| v.to_s.empty? }
+      features.delete_if { |k, v| k.nil? || v.to_s.empty? }
       features.transform_keys! { |k| k.gsub(/\s+/, '_').downcase.to_sym }
     end
 

--- a/lib/sports_south/catalog.rb
+++ b/lib/sports_south/catalog.rb
@@ -102,10 +102,12 @@ module SportsSouth
       items = []
 
       pages.times do |page|
-        items.concat(
-          fetch_items(last_update: last_update,
-                      last_item: cursor)
-        )
+        page_items = fetch_items(last_update: last_update,
+                                 last_item: cursor)
+
+        break if page_items.empty?
+
+        items.concat(page_items)
         cursor = items.last[:item_identifier]
       end
 
@@ -179,7 +181,7 @@ module SportsSouth
     end
 
     def map_features(attributes, node)
-      return {} if attributes.blank?
+      return {} if attributes.empty?
 
       features = {
         attributes[:attribute_1]  => content_for(node, 'ITATR1'),

--- a/lib/sports_south/inventory.rb
+++ b/lib/sports_south/inventory.rb
@@ -5,145 +5,144 @@ module SportsSouth
     ITEM_NODE_NAME = 'Onhand'
 
     def initialize(options = {})
-    requires!(options, :username, :password)
+      requires!(options, :username, :password)
 
-    @options = options
+      @options = options
+    end
+
+    def self.get_quantity_file(options = {})
+      requires!(options, :username, :password)
+
+      options[:last_updated] = '1990-09-25T14:15:47-04:00'
+      options[:last_item]    = '-1'
+
+      new(options).get_quantity_file
+    end
+
+    def self.all(options = {})
+      requires!(options, :username, :password)
+
+      if options[:last_updated].present?
+        options[:last_updated] = options[:last_updated].strftime('%Y-%m-%dT%H:%M:00.00%:z')
+      else
+        options[:last_updated] = '1990-09-25T14:15:47-04:00'
+      end
+
+      options[:last_item] ||= '-1'
+
+      new(options).all
+    end
+
+    def self.get(item_identifier, options = {})
+      requires!(options, :username, :password)
+      new(options).get(item_identifier)
+    end
+
+    def all
+      http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
+
+      request.set_form_data(form_params = form_params(@options).merge({
+        SinceDateTime: @options[:last_updated],
+        LastItem:      @options[:last_item].to_s
+      }))
+
+      items    = []
+      tempfile = download_to_tempfile(http, request)
+
+      tempfile.rewind
+
+      Nokogiri::XML::Reader.from_io(tempfile).each do |reader|
+        next unless reader.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+        next unless reader.name == ITEM_NODE_NAME
+
+        node = Nokogiri::XML.parse(reader.outer_xml)
+
+        _map_hash = map_hash(node.css(ITEM_NODE_NAME))
+
+        items << _map_hash unless _map_hash.nil?
+      end
+
+      tempfile.close
+      tempfile.unlink
+
+      items
+    end
+
+    def get_quantity_file
+      tempfile      = Tempfile.new
+      http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
+
+      request.set_form_data(form_params = form_params(@options).merge({
+        SinceDateTime: @options[:last_updated],
+        LastItem:      @options[:last_item].to_s
+      }))
+
+      response = http.request(request)
+      xml_doc  = Nokogiri::XML(sanitize_response(response))
+
+      xml_doc.css('Onhand').map do |item|
+        tempfile.puts("#{content_for(item, 'I')},#{content_for(item, 'Q')}")
+      end
+
+      tempfile.close
+      tempfile.path
+    end
+
+    def self.quantity(options = {})
+      requires!(options, :username, :password)
+
+      if options[:last_updated].present?
+        options[:last_updated] = options[:last_updated].to_s("yyyy-MM-ddTHH:mm:sszzz")
+      else
+        options[:last_updated] = '1990-09-25T14:15:47-04:00'
+      end
+
+      options[:last_item] ||= '-1'
+
+      new(options).all
+    end
+
+    def self.daily_item_count(options = {})
+      requires!(options, :username, :password, :last_update)
+
+      new(options).daily_item_count
+    end
+
+    def get(item_identifier)
+      http, request = get_http_and_request(API_URL, '/OnhandInquiry')
+
+      request.set_form_data(form_params(@options).merge({ ItemNumber: item_identifier }))
+
+      response = http.request(request)
+      xml_doc  = Nokogiri::XML(sanitize_response(response))
+    end
+
+    def daily_item_count
+      http, request = get_http_and_request(API_URL, '/DailyItemCount')
+      last_update_formatted = @options[:last_update]
+
+      if last_update_formatted.is_a?(Date)
+        last_update_formatted = last_update_formatted.strftime('%m/%d/%Y')
+      end
+
+      request.set_form_data(form_params(@options).merge({
+        LastUpdate: last_update_formatted
+      }))
+
+      response = http.request(request)
+      xml_doc  = Nokogiri::XML(sanitize_response(response))
+
+      content_for(xml_doc, 'int').to_i
+    end
+
+    protected
+
+    def map_hash(node)
+      {
+        item_identifier: content_for(node, 'I'),
+        quantity: content_for(node, 'Q').to_i,
+        price: content_for(node, 'C')
+      }
+    end
   end
-
-  def self.get_quantity_file(options = {})
-  requires!(options, :username, :password)
-
-  options[:last_updated] = '1990-09-25T14:15:47-04:00'
-  options[:last_item]    = '-1'
-
-  new(options).get_quantity_file
-end
-
-def self.all(options = {})
-requires!(options, :username, :password)
-
-if options[:last_updated].present?
-  options[:last_updated] = options[:last_updated].strftime('%Y-%m-%dT%H:%M:00.00%:z')
-else
-  options[:last_updated] = '1990-09-25T14:15:47-04:00'
-end
-
-options[:last_item] ||= '-1'
-
-new(options).all
-end
-
-def self.get(item_identifier, options = {})
-requires!(options, :username, :password)
-new(options).get(item_identifier)
-end
-
-def all
-  http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
-
-  request.set_form_data(form_params = form_params(@options).merge({
-  SinceDateTime: @options[:last_updated],
-  LastItem:      @options[:last_item].to_s
-  }))
-
-  items    = []
-  tempfile = download_to_tempfile(http, request)
-
-  tempfile.rewind
-
-  Nokogiri::XML::Reader.from_io(tempfile).each do |reader|
-    next unless reader.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
-    next unless reader.name == ITEM_NODE_NAME
-
-    node = Nokogiri::XML.parse(reader.outer_xml)
-
-    _map_hash = map_hash(node.css(ITEM_NODE_NAME))
-
-    items << _map_hash unless _map_hash.nil?
-  end
-
-  tempfile.close
-  tempfile.unlink
-
-  items
-end
-
-def get_quantity_file
-  tempfile      = Tempfile.new
-  http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
-
-  request.set_form_data(form_params = form_params(@options).merge({
-  SinceDateTime: @options[:last_updated],
-  LastItem:      @options[:last_item].to_s
-  }))
-
-  response = http.request(request)
-  xml_doc  = Nokogiri::XML(sanitize_response(response))
-
-  xml_doc.css('Onhand').map do |item|
-    tempfile.puts("#{content_for(item, 'I')},#{content_for(item, 'Q')}")
-  end
-
-  tempfile.close
-  tempfile.path
-end
-
-def self.quantity(options = {})
-requires!(options, :username, :password)
-
-if options[:last_updated].present?
-  options[:last_updated] = options[:last_updated].to_s("yyyy-MM-ddTHH:mm:sszzz")
-else
-  options[:last_updated] = '1990-09-25T14:15:47-04:00'
-end
-
-options[:last_item] ||= '-1'
-
-new(options).all
-end
-
-def self.daily_item_count(options = {})
-requires!(options, :username, :password, :last_update)
-
-new(options).daily_item_count
-end
-
-def get(item_identifier)
-  http, request = get_http_and_request(API_URL, '/OnhandInquiry')
-
-  request.set_form_data(form_params(@options).merge({ ItemNumber: item_identifier }))
-
-  response = http.request(request)
-  xml_doc  = Nokogiri::XML(sanitize_response(response))
-end
-
-def daily_item_count
-  http, request = get_http_and_request(API_URL, '/DailyItemCount')
-  last_update_formatted = @options[:last_update]
-
-  if last_update_formatted.is_a?(Date)
-    last_update_formatted = last_update_formatted.strftime('%m/%d/%Y')
-  end
-
-  request.set_form_data(form_params(@options).merge({
-  LastUpdate: last_update_formatted
-  }))
-
-  response = http.request(request)
-  xml_doc  = Nokogiri::XML(sanitize_response(response))
-
-  content_for(xml_doc, 'int').to_i
-end
-
-protected
-
-def map_hash(node)
-  {
-  item_identifier: content_for(node, 'I'),
-  quantity: content_for(node, 'Q').to_i,
-  price: content_for(node, 'C')
-}
-end
-
-end
 end

--- a/lib/sports_south/inventory.rb
+++ b/lib/sports_south/inventory.rb
@@ -102,6 +102,12 @@ module SportsSouth
       new(options).all
     end
 
+    def self.daily_item_count(options = {})
+      requires!(options, :username, :password, :last_update)
+
+      new(options).daily_item_count
+    end
+
     def get(item_identifier)
       http, request = get_http_and_request(API_URL, '/OnhandInquiry')
 
@@ -109,6 +115,21 @@ module SportsSouth
 
       response = http.request(request)
       xml_doc  = Nokogiri::XML(sanitize_response(response))
+    end
+
+    def daily_item_count
+      http, request = get_http_and_request(API_URL, '/DailyItemCount')
+
+      last_update_formatted = @options[:last_update].strftime('%m/%d/%Y')
+
+      request.set_form_data(form_params(@options).merge({
+        LastUpdate: last_update_formatted
+      }))
+
+      response = http.request(request)
+      xml_doc  = Nokogiri::XML(sanitize_response(response))
+
+      content_for(xml_doc, 'int').to_i
     end
 
     protected

--- a/lib/sports_south/inventory.rb
+++ b/lib/sports_south/inventory.rb
@@ -5,142 +5,145 @@ module SportsSouth
     ITEM_NODE_NAME = 'Onhand'
 
     def initialize(options = {})
-      requires!(options, :username, :password)
+    requires!(options, :username, :password)
 
-      @options = options
-    end
-
-    def self.get_quantity_file(options = {})
-      requires!(options, :username, :password)
-
-      options[:last_updated] = '1990-09-25T14:15:47-04:00'
-      options[:last_item]    = '-1'
-
-      new(options).get_quantity_file
-    end
-
-    def self.all(options = {})
-      requires!(options, :username, :password)
-
-      if options[:last_updated].present?
-        options[:last_updated] = options[:last_updated].strftime('%Y-%m-%dT%H:%M:00.00%:z')
-      else
-        options[:last_updated] = '1990-09-25T14:15:47-04:00'
-      end
-
-      options[:last_item] ||= '-1'
-
-      new(options).all
-    end
-
-    def self.get(item_identifier, options = {})
-      requires!(options, :username, :password)
-      new(options).get(item_identifier)
-    end
-
-    def all
-      http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
-
-      request.set_form_data(form_params = form_params(@options).merge({
-        SinceDateTime: @options[:last_updated],
-        LastItem:      @options[:last_item].to_s
-      }))
-
-      items    = []
-      tempfile = download_to_tempfile(http, request)
-
-      tempfile.rewind
-
-      Nokogiri::XML::Reader.from_io(tempfile).each do |reader|
-        next unless reader.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
-        next unless reader.name == ITEM_NODE_NAME
-
-        node = Nokogiri::XML.parse(reader.outer_xml)
-
-        _map_hash = map_hash(node.css(ITEM_NODE_NAME))
-
-        items << _map_hash unless _map_hash.nil?
-      end
-
-      tempfile.close
-      tempfile.unlink
-
-      items
-    end
-
-    def get_quantity_file
-      tempfile      = Tempfile.new
-      http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
-
-      request.set_form_data(form_params = form_params(@options).merge({
-        SinceDateTime: @options[:last_updated],
-        LastItem:      @options[:last_item].to_s
-      }))
-
-      response = http.request(request)
-      xml_doc  = Nokogiri::XML(sanitize_response(response))
-
-      xml_doc.css('Onhand').map do |item|
-        tempfile.puts("#{content_for(item, 'I')},#{content_for(item, 'Q')}")
-      end
-
-      tempfile.close
-      tempfile.path
-    end
-
-    def self.quantity(options = {})
-      requires!(options, :username, :password)
-
-      if options[:last_updated].present?
-        options[:last_updated] = options[:last_updated].to_s("yyyy-MM-ddTHH:mm:sszzz")
-      else
-        options[:last_updated] = '1990-09-25T14:15:47-04:00'
-      end
-
-      options[:last_item] ||= '-1'
-
-      new(options).all
-    end
-
-    def self.daily_item_count(options = {})
-      requires!(options, :username, :password, :last_update)
-
-      new(options).daily_item_count
-    end
-
-    def get(item_identifier)
-      http, request = get_http_and_request(API_URL, '/OnhandInquiry')
-
-      request.set_form_data(form_params(@options).merge({ ItemNumber: item_identifier }))
-
-      response = http.request(request)
-      xml_doc  = Nokogiri::XML(sanitize_response(response))
-    end
-
-    def daily_item_count
-      http, request = get_http_and_request(API_URL, '/DailyItemCount')
-
-      last_update_formatted = @options[:last_update].strftime('%m/%d/%Y')
-
-      request.set_form_data(form_params(@options).merge({
-        LastUpdate: last_update_formatted
-      }))
-
-      response = http.request(request)
-      xml_doc  = Nokogiri::XML(sanitize_response(response))
-
-      content_for(xml_doc, 'int').to_i
-    end
-
-    protected
-
-    def map_hash(node)
-      {
-        item_identifier: content_for(node, 'I'),
-        quantity: content_for(node, 'Q').to_i,
-        price: content_for(node, 'C')
-      }
-    end
-
+    @options = options
   end
+
+  def self.get_quantity_file(options = {})
+  requires!(options, :username, :password)
+
+  options[:last_updated] = '1990-09-25T14:15:47-04:00'
+  options[:last_item]    = '-1'
+
+  new(options).get_quantity_file
+end
+
+def self.all(options = {})
+requires!(options, :username, :password)
+
+if options[:last_updated].present?
+  options[:last_updated] = options[:last_updated].strftime('%Y-%m-%dT%H:%M:00.00%:z')
+else
+  options[:last_updated] = '1990-09-25T14:15:47-04:00'
+end
+
+options[:last_item] ||= '-1'
+
+new(options).all
+end
+
+def self.get(item_identifier, options = {})
+requires!(options, :username, :password)
+new(options).get(item_identifier)
+end
+
+def all
+  http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
+
+  request.set_form_data(form_params = form_params(@options).merge({
+  SinceDateTime: @options[:last_updated],
+  LastItem:      @options[:last_item].to_s
+  }))
+
+  items    = []
+  tempfile = download_to_tempfile(http, request)
+
+  tempfile.rewind
+
+  Nokogiri::XML::Reader.from_io(tempfile).each do |reader|
+    next unless reader.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+    next unless reader.name == ITEM_NODE_NAME
+
+    node = Nokogiri::XML.parse(reader.outer_xml)
+
+    _map_hash = map_hash(node.css(ITEM_NODE_NAME))
+
+    items << _map_hash unless _map_hash.nil?
+  end
+
+  tempfile.close
+  tempfile.unlink
+
+  items
+end
+
+def get_quantity_file
+  tempfile      = Tempfile.new
+  http, request = get_http_and_request(API_URL, '/IncrementalOnhandUpdate')
+
+  request.set_form_data(form_params = form_params(@options).merge({
+  SinceDateTime: @options[:last_updated],
+  LastItem:      @options[:last_item].to_s
+  }))
+
+  response = http.request(request)
+  xml_doc  = Nokogiri::XML(sanitize_response(response))
+
+  xml_doc.css('Onhand').map do |item|
+    tempfile.puts("#{content_for(item, 'I')},#{content_for(item, 'Q')}")
+  end
+
+  tempfile.close
+  tempfile.path
+end
+
+def self.quantity(options = {})
+requires!(options, :username, :password)
+
+if options[:last_updated].present?
+  options[:last_updated] = options[:last_updated].to_s("yyyy-MM-ddTHH:mm:sszzz")
+else
+  options[:last_updated] = '1990-09-25T14:15:47-04:00'
+end
+
+options[:last_item] ||= '-1'
+
+new(options).all
+end
+
+def self.daily_item_count(options = {})
+requires!(options, :username, :password, :last_update)
+
+new(options).daily_item_count
+end
+
+def get(item_identifier)
+  http, request = get_http_and_request(API_URL, '/OnhandInquiry')
+
+  request.set_form_data(form_params(@options).merge({ ItemNumber: item_identifier }))
+
+  response = http.request(request)
+  xml_doc  = Nokogiri::XML(sanitize_response(response))
+end
+
+def daily_item_count
+  http, request = get_http_and_request(API_URL, '/DailyItemCount')
+  last_update_formatted = @options[:last_update]
+
+  if last_update_formatted.is_a?(Date)
+    last_update_formatted = last_update_formatted.strftime('%m/%d/%Y')
+  end
+
+  request.set_form_data(form_params(@options).merge({
+  LastUpdate: last_update_formatted
+  }))
+
+  response = http.request(request)
+  xml_doc  = Nokogiri::XML(sanitize_response(response))
+
+  content_for(xml_doc, 'int').to_i
+end
+
+protected
+
+def map_hash(node)
+  {
+  item_identifier: content_for(node, 'I'),
+  quantity: content_for(node, 'Q').to_i,
+  price: content_for(node, 'C')
+}
+end
+
+end
 end

--- a/lib/sports_south/version.rb
+++ b/lib/sports_south/version.rb
@@ -1,3 +1,3 @@
 module SportsSouth
-  VERSION = '5.0.1'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/lib/sports_south/version.rb
+++ b/lib/sports_south/version.rb
@@ -1,3 +1,3 @@
 module SportsSouth
-  VERSION = '5.1.0'.freeze
+  VERSION = '6.0.0'.freeze
 end

--- a/spec/fixtures/daily_item_count.xml
+++ b/spec/fixtures/daily_item_count.xml
@@ -1,0 +1,1 @@
+<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">42</int>

--- a/spec/sports_south/catalog_spec.rb
+++ b/spec/sports_south/catalog_spec.rb
@@ -2,62 +2,169 @@ require 'spec_helper'
 
 describe SportsSouth::Catalog do
 
+  API_BASE = 'http://webservices.theshootingwarehouse.com/smart/inventory.asmx'
+
   let(:credentials) { { username: 'usr', password: 'pa$$' } }
 
   before do
-    allow(SportsSouth::Category).to receive(:all).with(credentials) do
+    allow(SportsSouth::Category).to receive(:all) do
       @categories_file ||= FixtureHelper.get_fixture('categories.json')
       @categories      ||= JSON.parse(@categories_file.read, symbolize_names: true)
     end
 
-    allow(SportsSouth::Brand).to receive(:all).with(credentials) do
+    allow(SportsSouth::Brand).to receive(:all) do
       @brands_file ||= FixtureHelper.get_fixture('brands.json')
       @brands      ||= JSON.parse(@brands_file.read, symbolize_names: true)
     end
-
-    tempfile = Tempfile.new('daily_item_update')
-    FileUtils.copy_file(FixtureHelper.get_fixture('daily_item_update.xml').path, tempfile.path)
-    allow_any_instance_of(SportsSouth::Catalog).to receive(:download_to_tempfile) { tempfile }
   end
 
   describe '.all' do
-    it 'returns all items in an array' do
-      items = SportsSouth::Catalog.all(credentials)
+    context 'with a single page of results' do
+      before do
+        stub_request(:post, "#{API_BASE}/DailyItemUpdate").
+          to_return(status: 200, body: FixtureHelper.get_fixture('daily_item_update.xml').read)
 
-      items.each_with_index do |item, index|
-        case index
-        when 0
-          expect(item[:name]).to            eq('Reginald Ammo-1')
-          expect(item[:upc]).to             eq('123000000001')
-          expect(item[:item_identifier]).to eq('50001')
-          expect(item[:price]).to           eq('11.89')
-          expect(item[:quantity]).to        eq(25)
-          expect(item[:category]).to        eq('Cool Category')
-          expect(item[:brand]).to           eq('Brand 1')
-          expect(item[:caliber]).to         eq(nil)
-        when 1
-          expect(item[:name]).to            eq('MMM Handgun-1')
-          expect(item[:upc]).to             eq('123000000002')
-          expect(item[:item_identifier]).to eq('50002')
-          expect(item[:price]).to           eq('110.99')
-          expect(item[:quantity]).to        eq(25)
-          expect(item[:category]).to        eq('Cool Category')
-          expect(item[:brand]).to           eq('Brand 2')
-          expect(item[:caliber]).to         eq('9MM')
-        when 55
-          expect(item[:name]).to            eq('Model 56 Handgun-8')
-          expect(item[:upc]).to             eq('123000000056')
-          expect(item[:item_identifier]).to eq('50056')
-          expect(item[:price]).to           eq('422.62')
-          expect(item[:quantity]).to        eq(10)
-          expect(item[:category]).to        eq('Marshmallow Guns')
-          expect(item[:brand]).to           eq('Brand 3')
-          expect(item[:caliber]).to         eq('380')
-          expect(item[:weight]).to          eq('2.3')
-        end
+        stub_request(:post, "#{API_BASE}/DailyItemCount").
+          to_return(status: 200, body: '<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">56</int>')
       end
 
-      expect(items.count).to eq(56)
+      it 'returns all items in an array' do
+        items = SportsSouth::Catalog.all(credentials)
+
+        items.each_with_index do |item, index|
+          case index
+          when 0
+            expect(item[:name]).to            eq('Reginald Ammo-1')
+            expect(item[:upc]).to             eq('123000000001')
+            expect(item[:item_identifier]).to eq('50001')
+            expect(item[:price]).to           eq('11.89')
+            expect(item[:quantity]).to        eq(25)
+            expect(item[:category]).to        eq('Cool Category')
+            expect(item[:brand]).to           eq('Brand 1')
+            expect(item[:caliber]).to         eq(nil)
+          when 1
+            expect(item[:name]).to            eq('MMM Handgun-1')
+            expect(item[:upc]).to             eq('123000000002')
+            expect(item[:item_identifier]).to eq('50002')
+            expect(item[:price]).to           eq('110.99')
+            expect(item[:quantity]).to        eq(25)
+            expect(item[:category]).to        eq('Cool Category')
+            expect(item[:brand]).to           eq('Brand 2')
+            expect(item[:caliber]).to         eq('9MM')
+          when 55
+            expect(item[:name]).to            eq('Model 56 Handgun-8')
+            expect(item[:upc]).to             eq('123000000056')
+            expect(item[:item_identifier]).to eq('50056')
+            expect(item[:price]).to           eq('422.62')
+            expect(item[:quantity]).to        eq(10)
+            expect(item[:category]).to        eq('Marshmallow Guns')
+            expect(item[:brand]).to           eq('Brand 3')
+            expect(item[:caliber]).to         eq('380')
+            expect(item[:weight]).to          eq('2.3')
+          end
+        end
+
+        expect(items.count).to eq(56)
+      end
+    end
+
+    context 'when daily_item_count > 1000' do
+      let(:page1_xml) do
+        <<~XML
+          <string xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">
+            <NewDataSet>
+              <Table>
+                <ITEMNO>10001</ITEMNO><ITUPC>000000010001</ITUPC><CPRC>9.99</CPRC>
+                <QTYOH>5</QTYOH><CATID>5</CATID><ITBRDNO>1</ITBRDNO>
+                <IMODEL>Model A</IMODEL><MFGINO>SKU-A</MFGINO><SERIES>S1</SERIES>
+                <ITYPE>3</ITYPE><WTPBX>1.0</WTPBX><MFPRC>0</MFPRC><UOM>BX</UOM>
+                <SHDESC>Item A</SHDESC>
+              </Table>
+              <Table>
+                <ITEMNO>10002</ITEMNO><ITUPC>000000010002</ITUPC><CPRC>19.99</CPRC>
+                <QTYOH>10</QTYOH><CATID>5</CATID><ITBRDNO>2</ITBRDNO>
+                <IMODEL>Model B</IMODEL><MFGINO>SKU-B</MFGINO><SERIES>S2</SERIES>
+                <ITYPE>3</ITYPE><WTPBX>2.0</WTPBX><MFPRC>0</MFPRC><UOM>BX</UOM>
+                <SHDESC>Item B</SHDESC>
+              </Table>
+            </NewDataSet>
+          </string>
+        XML
+      end
+
+      let(:page2_xml) do
+        <<~XML
+          <string xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">
+            <NewDataSet>
+              <Table>
+                <ITEMNO>10003</ITEMNO><ITUPC>000000010003</ITUPC><CPRC>29.99</CPRC>
+                <QTYOH>3</QTYOH><CATID>5</CATID><ITBRDNO>3</ITBRDNO>
+                <IMODEL>Model C</IMODEL><MFGINO>SKU-C</MFGINO><SERIES>S3</SERIES>
+                <ITYPE>3</ITYPE><WTPBX>3.0</WTPBX><MFPRC>0</MFPRC><UOM>BX</UOM>
+                <SHDESC>Item C</SHDESC>
+              </Table>
+            </NewDataSet>
+          </string>
+        XML
+      end
+
+      before do
+        stub_request(:post, "#{API_BASE}/DailyItemCount").
+          to_return(status: 200, body: '<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">1200</int>')
+
+        stub_request(:post, "#{API_BASE}/DailyItemUpdate").
+          with(body: hash_including('LastItem' => '-1')).
+          to_return(status: 200, body: page1_xml)
+
+        stub_request(:post, "#{API_BASE}/DailyItemUpdate").
+          with(body: hash_including('LastItem' => '10002')).
+          to_return(status: 200, body: page2_xml)
+      end
+
+      it 'fetches all pages and concatenates results' do
+        items = SportsSouth::Catalog.all(credentials)
+
+        expect(items.count).to eq(3)
+        expect(items[0][:item_identifier]).to eq('10001')
+        expect(items[1][:item_identifier]).to eq('10002')
+        expect(items[2][:item_identifier]).to eq('10003')
+      end
+    end
+
+    context 'with full_product: true' do
+      let(:item_xml) do
+        <<~XML
+          <string xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">
+            <NewDataSet>
+              <Table>
+                <ITEMNO>20001</ITEMNO><ITUPC>000000020001</ITUPC><CPRC>49.99</CPRC>
+                <QTYOH>7</QTYOH><CATID>5</CATID><ITBRDNO>1</ITBRDNO>
+                <IMODEL>Full Model</IMODEL><MFGINO>FM-1</MFGINO><SERIES>FS</SERIES>
+                <ITYPE>3</ITYPE><WTPBX>1.5</WTPBX><MFPRC>0</MFPRC><UOM>BX</UOM>
+                <SHDESC>Full Item</SHDESC>
+              </Table>
+            </NewDataSet>
+          </string>
+        XML
+      end
+
+      before do
+        stub_request(:post, "#{API_BASE}/DailyItemUpdate").
+          to_return(status: 200, body: item_xml)
+
+        stub_request(:post, "#{API_BASE}/DailyItemCount").
+          to_return(status: 200, body: '<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">1</int>')
+
+        stub_request(:post, "#{API_BASE}/GetText").
+          to_return(status: 200, body: '<string xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx"><CATALOGTEXT>A detailed product description</CATALOGTEXT></string>')
+      end
+
+      it 'fetches long descriptions for all items' do
+        items = SportsSouth::Catalog.all(credentials.merge(full_product: true))
+
+        expect(items.count).to eq(1)
+        expect(items.first[:long_description]).to eq('A detailed product description')
+      end
     end
   end
 

--- a/spec/sports_south/catalog_spec.rb
+++ b/spec/sports_south/catalog_spec.rb
@@ -113,7 +113,7 @@ describe SportsSouth::Catalog do
           to_return(status: 200, body: '<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">1200</int>')
 
         stub_request(:post, "#{API_BASE}/DailyItemUpdate").
-          with(body: hash_including('LastItem' => '-1')).
+          with(body: hash_including('LastItem' => '0')).
           to_return(status: 200, body: page1_xml)
 
         stub_request(:post, "#{API_BASE}/DailyItemUpdate").
@@ -122,7 +122,7 @@ describe SportsSouth::Catalog do
       end
 
       it 'fetches all pages and concatenates results' do
-        items = SportsSouth::Catalog.all(credentials)
+        items = SportsSouth::Catalog.all(credentials.merge(last_item: 0))
 
         expect(items.count).to eq(3)
         expect(items[0][:item_identifier]).to eq('10001')
@@ -182,6 +182,43 @@ describe SportsSouth::Catalog do
 
         expect(items.count).to eq(54)
         expect(items.map { |i| i[:upc] }).not_to include('123000000001', '123000000056')
+      end
+    end
+  end
+
+  describe '#map_features' do
+    let(:catalog) { SportsSouth::Catalog.new(credentials) }
+
+    context 'when category lookup returns nil (attributes is an empty hash)' do
+      let(:node_no_itatr) do
+        Nokogiri::XML.parse('<Table></Table>').css('Table')
+      end
+
+      let(:node_with_itatr20) do
+        Nokogiri::XML.parse('<Table><ITATR20>SomeValue</ITATR20></Table>').css('Table')
+      end
+
+      let(:node_with_itatr1_only) do
+        Nokogiri::XML.parse('<Table><ITATR1>Pistol</ITATR1></Table>').css('Table')
+      end
+
+      it 'returns an empty hash when no ITATR values are present' do
+        result = catalog.send(:map_features, {}, node_no_itatr)
+        expect(result).to eq({})
+      end
+
+      it 'does not raise an error when ITATR20 has a value' do
+        expect { catalog.send(:map_features, {}, node_with_itatr20) }.not_to raise_error
+      end
+
+      it 'returns a hash without nil keys when ITATR20 has a value' do
+        result = catalog.send(:map_features, {}, node_with_itatr20)
+        expect(result.keys).not_to include(nil)
+      end
+
+      it 'returns an empty hash when only earlier ITATR fields have values' do
+        result = catalog.send(:map_features, {}, node_with_itatr1_only)
+        expect(result).to eq({})
       end
     end
   end

--- a/spec/sports_south/catalog_spec.rb
+++ b/spec/sports_south/catalog_spec.rb
@@ -166,6 +166,24 @@ describe SportsSouth::Catalog do
         expect(items.first[:long_description]).to eq('A detailed product description')
       end
     end
+
+    context 'with upcs_to_not_process' do
+      before do
+        stub_request(:post, "#{API_BASE}/DailyItemUpdate").
+          to_return(status: 200, body: FixtureHelper.get_fixture('daily_item_update.xml').read)
+
+        stub_request(:post, "#{API_BASE}/DailyItemCount").
+          to_return(status: 200, body: '<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">56</int>')
+      end
+
+      it 'excludes items whose UPC is present in the lookup hash' do
+        skip_upcs = Set['123000000001', '123000000056']
+        items = SportsSouth::Catalog.all(credentials.merge(upcs_to_not_process: skip_upcs))
+
+        expect(items.count).to eq(54)
+        expect(items.map { |i| i[:upc] }).not_to include('123000000001', '123000000056')
+      end
+    end
   end
 
 end

--- a/spec/sports_south/inventory_spec.rb
+++ b/spec/sports_south/inventory_spec.rb
@@ -43,4 +43,15 @@ describe SportsSouth::Inventory do
     end
   end
 
+  describe '.daily_item_count' do
+    it 'returns the count of items' do
+      response_body = '<int xmlns="http://webservices.theshootingwarehouse.com/smart/Inventory.asmx">42</int>'
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(double(body: response_body))
+
+      count = SportsSouth::Inventory.daily_item_count(credentials.merge(last_update: Date.today))
+
+      expect(count).to eq(42)
+    end
+  end
+
 end


### PR DESCRIPTION
  ## Problem

  `Catalog.all` with `LastItem: -1` asks the API for the entire catalog in a
  single request. For large catalogs, or when combining `LastUpdate` with a
  broad date range, the API times out before returning a response.

  ## Solution

  Introduce cursor-based pagination using the `DailyItemCount` endpoint to
  determine the number of pages upfront, then iterate through them using the
  last item number from each response as the cursor for the next request.

  Callers opt into this mode by passing `last_item: <item_number>` (any value
  ≥ 0). The default (`last_item: -1`) preserves the existing single-request
  behavior for smaller pulls.

  ## Performance improvements

  - Categories and brands are now indexed as hashes on load, making per-item
    lookup O(1) instead of O(n)
  - Brand names are resolved inline during XML streaming, removing the O(n²)
    post-processing loop (`assign_brand_names`)
  - Items matching `upcs_to_not_process` are rejected during streaming before
    any object allocation or `GetText` requests

  ## Breaking changes

  - Option key renamed: `:last_updated` → `:last_update